### PR TITLE
feat: add random reviewer workflow

### DIFF
--- a/.github/workflows/assign-random-reviewer.yml
+++ b/.github/workflows/assign-random-reviewer.yml
@@ -1,0 +1,79 @@
+name: Assign random reviewer
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write  # 코멘트 작성용
+
+env:
+  REVIEWER_POOL: |
+    juncity-kim
+    jaeaeee
+    doublejh0501
+    zneda330
+  REVIEWER_COUNT: "1"
+
+jobs:
+  roulette:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pick random reviewer & request review
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr || pr.draft) {
+              core.notice("Draft PR or no PR payload – skipping.");
+              return;
+            }
+
+            // 1) 후보 풀 불러오기
+            const pool = (process.env.REVIEWER_POOL || "")
+              .split("\n").map(s => s.trim()).filter(Boolean);
+
+            // 2) 작성자 / 이미 요청된 리뷰어 제외
+            const author = pr.user.login.toLowerCase();
+            let candidates = pool.filter(u => u.toLowerCase() !== author);
+
+            const already = (pr.requested_reviewers || [])
+              .map(u => u.login.toLowerCase());
+            candidates = candidates.filter(u => !already.includes(u.toLowerCase()));
+
+            if (candidates.length === 0) {
+              core.notice("No available reviewers after excluding author/already-requested.");
+              return;
+            }
+
+            // 3) 랜덤 셔플 + 1명 선택
+            const need = Math.min(parseInt(process.env.REVIEWER_COUNT || "1", 10), candidates.length);
+            for (let i = candidates.length - 1; i > 0; i--) {
+              const j = Math.floor(Math.random() * (i + 1));
+              [candidates[i], candidates[j]] = [candidates[j], candidates[i]];
+            }
+            const chosen = candidates.slice(0, need);
+
+            // 4) 리뷰어 요청
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              reviewers: chosen,
+            });
+
+            // 5) 코멘트 남기기 (슬랙 구독이 있다면 이 코멘트가 슬랙에도 자동 전송됨)
+            const body = `@${chosen.join(", @")} 님, 랜덤 리뷰 미션이 도착했습니다! 🚀\n\n작성자: @${pr.user.login}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });
+
+            core.notice(`Requested review from: ${chosen.join(", ")}`);
+
+            


### PR DESCRIPTION
⭐Key Changes
핵심 변경 사항에 대해서 적어주세요.

PR 생성 시 팀원 중 1명을 자동으로 랜덤 리뷰어로 배정하도록 워크플로우 추가
PR 작성자는 자동 제외 처리
리뷰어에게 자동 코멘트 남기도록 설정 (Slack 연동 시 자동 알림 전송)
🩼Branch
반영 branch : feat-auto-reviewer -> main

👪To Reviewers
PR 생성 시 자동 리뷰어 배정 및 Slack 알림 정상 작동 여부 테스트 예정입니다.
