### PR TITLE
[feat] 웹 검색 provider 구현,CLI 파이프라인 안정화

### DIFF
--- a/config/websearch.yaml
+++ b/config/websearch.yaml
@@ -2,4 +2,22 @@ cache:
   directory: data/web_cache
   ttl_seconds: 86400
 provider:
+  base_url: https://api.upstage.ai/v1/web-search
+  method: GET
+  query_param: query
+  payload: params
+  params:
+    language: ko
+    size: 5
+  headers:
+    Authorization: Bearer ${UPSTAGE_SEARCH_KEY}
+  timeout: 8
   max_results: 5
+  response:
+    items_path:
+      - data
+      - results
+    title_field: title
+    url_field: url
+    snippet_field: snippet
+whitelist_path: src/websearch/whitelist.yaml

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -1,4 +1,8 @@
-"""LoanBot 인덱스 빌더."""
+"""LoanBot 인덱스 빌더.
+
+원천 데이터를 정제·청킹하고 결과를 JSONL로 저장한 뒤 후속 임베딩 파이프라인의
+입력을 준비한다.
+"""
 
 from __future__ import annotations
 
@@ -7,117 +11,159 @@ import logging
 import sys
 from dataclasses import replace
 from pathlib import Path
-from typing import Optional
+from typing import Sequence
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from config.settings import Settings, get_settings
 from src.core.logging import configure_logging as configure_app_logging
 from src.retrieval.config import RetrievalConfig, load_retrieval_config
-from src.retrieval.pipeline import IngestResult, RetrievalPipeline
+from src.retrieval.pipeline import RetrievalPipeline
 
 logger = logging.getLogger(__name__)
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="LoanBot 벡터 인덱스를 생성합니다.")
-    parser.add_argument("--config", type=Path, default=None, help="retrieval 설정 YAML 경로")
-    parser.add_argument("--raw-dir", type=Path, default=Path("data/raw"), help="원천 데이터 디렉터리")
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="retrieval 설정 YAML 경로 (기본값: config/retrieval.yaml)",
+    )
+    parser.add_argument(
+        "--raw-dir",
+        type=Path,
+        default=Path("data/raw"),
+        help="원천 데이터가 위치한 디렉터리",
+    )
     parser.add_argument(
         "--output-dir",
         type=Path,
         default=Path("data/processed"),
-        help="청킹 결과 저장 디렉터리",
+        help="정제/청킹 결과를 저장할 디렉터리",
     )
     parser.add_argument(
         "--chunk-filename",
         type=str,
         default="chunks.jsonl",
-        help="청크 결과 파일명",
+        help="청크 결과 JSONL 파일명",
     )
     parser.add_argument(
         "--document-filename",
         type=str,
         default="documents.json",
-        help="문서 메타데이터 파일명",
+        help="문서 메타데이터를 저장할 JSON 파일명",
     )
-    parser.add_argument("--skip-vectorstore", action="store_true", help="벡터스토어 업서트 생략")
-    parser.add_argument("--log-level", type=str, default="INFO", help="루트 로그 레벨")
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=None,
+        help="청크 최대 길이(문자) (설정 파일 우선)",
+    )
+    parser.add_argument(
+        "--chunk-overlap",
+        type=int,
+        default=None,
+        help="청크 간 겹침 길이(문자) (설정 파일 우선)",
+    )
+    parser.add_argument(
+        "--min-chunk-chars",
+        type=int,
+        default=None,
+        help="청크 최소 길이가 부족할 경우 병합 기준 (설정 파일 우선)",
+    )
+    parser.add_argument(
+        "--vectorstore-path",
+        type=Path,
+        default=None,
+        help="Chroma 퍼시스턴스 디렉터리 경로 (설정 파일 우선)",
+    )
+    parser.add_argument(
+        "--collection-name",
+        type=str,
+        default=None,
+        help="저장할 컬렉션명 (설정 파일 우선)",
+    )
+    parser.add_argument(
+        "--skip-vectorstore",
+        action="store_true",
+        help="임베딩 계산 및 벡터스토어 업서트를 생략",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+        help="루트 로거 레벨",
+    )
     return parser.parse_args(argv)
 
 
 def configure_logging(level: str) -> None:
     configure_app_logging()
-    logging.getLogger().setLevel(level.upper())
+    logging.getLogger().setLevel(level)
 
 
-def _merge_config(base: RetrievalConfig, settings: Settings) -> RetrievalConfig:
+def _merge_config(base: RetrievalConfig, args: argparse.Namespace) -> RetrievalConfig:
+    chunk = base.chunk
+    if args.chunk_size is not None:
+        chunk = replace(chunk, size=args.chunk_size)
+    if args.chunk_overlap is not None:
+        chunk = replace(chunk, overlap=args.chunk_overlap)
+    if args.min_chunk_chars is not None:
+        chunk = replace(chunk, min_chars=args.min_chunk_chars)
+
     vectorstore = base.vectorstore
-    if settings.vectorstore_path is not None:
-        vectorstore = replace(vectorstore, persist_directory=settings.vectorstore_path)
-    return RetrievalConfig(chunk=base.chunk, vectorstore=vectorstore, reranker=base.reranker)
+    if args.vectorstore_path is not None:
+        vectorstore = replace(vectorstore, persist_directory=args.vectorstore_path)
+    if args.collection_name is not None:
+        vectorstore = replace(vectorstore, collection_name=args.collection_name)
+
+    return RetrievalConfig(
+        chunk=chunk,
+        vectorstore=vectorstore,
+        reranker=base.reranker,
+        confidence=base.confidence,
+        embedding=base.embedding,
+    )
 
 
-def run_build_index(
-    *,
-    settings: Settings | None = None,
-    config_path: Optional[Path] = None,
-    raw_dir: Path | None = None,
-    output_dir: Path | None = None,
-    chunk_filename: str = "chunks.jsonl",
-    document_filename: str = "documents.json",
-    skip_vectorstore: bool = False,
-) -> IngestResult:
-    """Retrieval 파이프라인을 실행한다."""
+def run_build_index(args: argparse.Namespace) -> int:
+    if not args.raw_dir.exists():
+        raise FileNotFoundError(f"원천 데이터 디렉터리를 찾을 수 없습니다: {args.raw_dir}")
 
-    cfg = settings or get_settings()
-    base_config = load_retrieval_config(config_path) if config_path else load_retrieval_config()
-    effective_config = _merge_config(base_config, cfg)
+    base_config = load_retrieval_config(args.config) if args.config else load_retrieval_config()
+    effective_config = _merge_config(base_config, args)
     pipeline = RetrievalPipeline(config=effective_config)
 
     result = pipeline.ingest(
-        raw_dir=raw_dir or Path("data/raw"),
-        output_dir=output_dir or Path("data/processed"),
-        chunk_filename=chunk_filename,
-        document_filename=document_filename,
-        skip_vectorstore=skip_vectorstore,
+        raw_dir=args.raw_dir,
+        output_dir=args.output_dir,
+        chunk_filename=args.chunk_filename,
+        document_filename=args.document_filename,
+        persist_outputs=True,
+        skip_vectorstore=args.skip_vectorstore,
     )
 
-    if not skip_vectorstore and effective_config.vectorstore.persist_directory:
-        persist_dir = effective_config.vectorstore.persist_directory
-        if not persist_dir.exists():
-            raise FileNotFoundError(f"벡터스토어 디렉터리가 생성되지 않았습니다: {persist_dir}")
+    if not result.documents:
+        logger.warning("처리된 문서가 없어 종료합니다.")
+        return 0
 
-    return result
+    if args.skip_vectorstore:
+        logger.info("--skip-vectorstore 옵션으로 인해 벡터 저장을 생략합니다.")
+        return 0
 
-
-def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
-    configure_logging(args.log_level)
-
-    try:
-        result = run_build_index(
-            config_path=args.config,
-            raw_dir=args.raw_dir,
-            output_dir=args.output_dir,
-            chunk_filename=args.chunk_filename,
-            document_filename=args.document_filename,
-            skip_vectorstore=args.skip_vectorstore,
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.exception("인덱스 생성 실패: %s", exc)
-        return 1
-
-    logger.info(
-        "인덱스 생성 완료 - 문서 %d건, 청크 %d건, 업서트 %d건",
-        len(result.documents),
-        len(result.chunks),
-        result.upserted,
-    )
+    logger.info("벡터스토어 업서트 개수: %d", result.upserted)
     return 0
 
 
-if __name__ == "__main__":  # pragma: no cover
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    configure_logging(args.log_level)
+    return run_build_index(args)
+
+
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -2,43 +2,73 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import List
+
 import typer
 
 from scripts.build_index import main as build_index_main
-from scripts.evaluate import main as evaluate_main
+from scripts.evaluate_reranker import main as evaluate_reranker_main
 from scripts.refresh_kb import main as refresh_kb_main
 
 app = typer.Typer(help="LoanBot 운영/배포 파이프라인 도구")
 
 
-@app.command()
-def build_index() -> None:
-    """Retrieval 인덱스를 생성한다."""
+def _maybe_add(args: List[str], flag: str, value: Path | str | None) -> None:
+    if value is None:
+        return
+    args.extend([flag, str(value)])
 
-    exit_code = build_index_main([])
+
+@app.command("build-index")
+def build_index(
+    config: Path | None = typer.Option(None, help="retrieval 설정 YAML 경로"),
+    raw_dir: Path = typer.Option(Path("data/raw"), help="원천 데이터 디렉터리"),
+    output_dir: Path = typer.Option(Path("data/processed"), help="청킹 결과 저장 디렉터리"),
+    skip_vectorstore: bool = typer.Option(False, help="벡터스토어 업서트를 생략"),
+    log_level: str = typer.Option("INFO", help="로깅 레벨", case_sensitive=False),
+) -> None:
+    argv: List[str] = []
+    _maybe_add(argv, "--raw-dir", raw_dir)
+    _maybe_add(argv, "--output-dir", output_dir)
+    _maybe_add(argv, "--config", config)
+    if skip_vectorstore:
+        argv.append("--skip-vectorstore")
+    _maybe_add(argv, "--log-level", log_level)
+
+    exit_code = build_index_main(argv)
     raise typer.Exit(exit_code)
 
 
-@app.command()
-def refresh_kb() -> None:
-    """지식베이스를 증분 갱신한다."""
+@app.command("refresh-kb")
+def refresh_kb(
+    config: Path | None = typer.Option(None, help="retrieval 설정 YAML 경로"),
+    raw_dir: Path = typer.Option(Path("data/raw"), help="증분 업데이트할 데이터 디렉터리"),
+    output_dir: Path = typer.Option(Path("data/processed"), help="청킹 결과 저장 디렉터리"),
+    skip_vectorstore: bool = typer.Option(False, help="벡터스토어 업서트를 생략"),
+    log_level: str = typer.Option("INFO", help="로깅 레벨", case_sensitive=False),
+) -> None:
+    argv: List[str] = []
+    _maybe_add(argv, "--raw-dir", raw_dir)
+    _maybe_add(argv, "--output-dir", output_dir)
+    _maybe_add(argv, "--config", config)
+    if skip_vectorstore:
+        argv.append("--skip-vectorstore")
+    _maybe_add(argv, "--log-level", log_level)
 
-    try:
-        refresh_kb_main()
-    except NotImplementedError as exc:  # pragma: no cover - 추후 구현 예정
-        typer.secho(str(exc), fg=typer.colors.YELLOW)
-        raise typer.Exit(code=1) from exc
+    exit_code = refresh_kb_main(argv)
+    raise typer.Exit(exit_code)
 
 
-@app.command()
-def evaluate() -> None:
-    """오프라인 평가 루틴을 실행한다."""
-
-    try:
-        evaluate_main()
-    except NotImplementedError as exc:  # pragma: no cover - 추후 구현 예정
-        typer.secho(str(exc), fg=typer.colors.YELLOW)
-        raise typer.Exit(code=1) from exc
+@app.command("evaluate-reranker")
+def evaluate_reranker(
+    input_path: Path = typer.Option(..., "--input", help="평가할 후보 JSON/JSONL 경로"),
+    config: Path | None = typer.Option(None, help="retrieval 설정 YAML 경로"),
+) -> None:
+    argv: List[str] = ["--input", str(input_path)]
+    _maybe_add(argv, "--config", config)
+    exit_code = evaluate_reranker_main(argv)
+    raise typer.Exit(exit_code)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/scripts/evaluate_reranker.py
+++ b/scripts/evaluate_reranker.py
@@ -7,11 +7,9 @@ import json
 import sys
 from pathlib import Path
 from statistics import mean
-from typing import Any, Iterable
-
+from typing import Any, Iterable, Sequence
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
@@ -19,7 +17,7 @@ from src.retrieval.config import load_retrieval_config
 from src.retrieval.pipeline import RetrievalPipeline
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--input",
@@ -33,7 +31,7 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="retrieval 설정 YAML 경로",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def load_candidates(path: Path) -> list[dict[str, Any]]:
@@ -63,9 +61,7 @@ def summarize(scores: Iterable[float]) -> dict[str, float]:
     }
 
 
-def main() -> None:
-    args = parse_args()
-
+def run_evaluate_reranker(args: argparse.Namespace) -> int:
     config = load_retrieval_config(args.config) if args.config else load_retrieval_config()
     pipeline = RetrievalPipeline(config=config)
 
@@ -90,6 +86,13 @@ def main() -> None:
     for key, value in summary_norm.items():
         print(f"{key}: {value:.4f}")
 
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    return run_evaluate_reranker(args)
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/refresh_kb.py
+++ b/scripts/refresh_kb.py
@@ -2,11 +2,96 @@
 
 from __future__ import annotations
 
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Sequence
 
-def main() -> None:
-    """TODO: 변경 감지, 재청킹, 임베딩 갱신, 벡터스토어 업서트를 구현하세요."""
-    raise NotImplementedError("refresh_kb 로직을 구현하세요.")
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.core.logging import configure_logging as configure_app_logging
+from src.retrieval.config import load_retrieval_config
+from src.retrieval.pipeline import RetrievalPipeline
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="retrieval 설정 YAML 경로 (기본값: config/retrieval.yaml)",
+    )
+    parser.add_argument(
+        "--raw-dir",
+        type=Path,
+        default=Path("data/raw"),
+        help="증분 반영할 원천 데이터 디렉터리",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/processed"),
+        help="정제/청킹 결과 저장 디렉터리",
+    )
+    parser.add_argument(
+        "--skip-vectorstore",
+        action="store_true",
+        help="청킹 결과만 갱신하고 벡터스토어 업서트를 생략",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+        help="루트 로거 레벨",
+    )
+    return parser.parse_args(argv)
+
+
+def configure_logging(level: str) -> None:
+    configure_app_logging()
+    logging.getLogger().setLevel(level)
+
+
+def run_refresh_kb(args: argparse.Namespace) -> int:
+    if not args.raw_dir.exists():
+        raise FileNotFoundError(f"원천 데이터 디렉터리를 찾을 수 없습니다: {args.raw_dir}")
+
+    config = load_retrieval_config(args.config) if args.config else load_retrieval_config()
+    pipeline = RetrievalPipeline(config=config)
+
+    result = pipeline.ingest(
+        raw_dir=args.raw_dir,
+        output_dir=args.output_dir,
+        chunk_filename="chunks.jsonl",
+        document_filename="documents.json",
+        persist_outputs=True,
+        skip_vectorstore=args.skip_vectorstore,
+    )
+
+    if not result.documents:
+        logger.info("변경된 문서가 없어 종료합니다.")
+        return 0
+
+    if args.skip_vectorstore:
+        logger.info("--skip-vectorstore 옵션으로 인해 벡터 저장을 생략합니다.")
+        return 0
+
+    logger.info("업서트된 청크 수: %d", result.upserted)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    configure_logging(args.log_level)
+    return run_refresh_kb(args)
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/retrieval/config.py
+++ b/src/retrieval/config.py
@@ -15,24 +15,22 @@ _DEFAULT_CONFIG_PATH = Path("config/retrieval.yaml")
 logger = logging.getLogger(__name__)
 
 
-def _resolve_env(value: Any) -> Any:
-    if isinstance(value, str):
-        text = value.strip()
-        if text.startswith("${") and text.endswith("}"):
-            env_key = text[2:-1].strip()
-            if not env_key:
-                return ""
-            env_value = os.getenv(env_key)
-            if env_value is None:
-                logger.warning("환경변수 %s 를 찾을 수 없습니다.", env_key)
-                return ""
-            return env_value
-        return text
-    if isinstance(value, dict):
-        return {key: _resolve_env(val) for key, val in value.items()}
-    if isinstance(value, list):
-        return [_resolve_env(item) for item in value]
-    return value
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.startswith("${") and text.endswith("}"):
+        env_key = text[2:-1].strip()
+        if not env_key:
+            return None
+        env_value = os.getenv(env_key)
+        if env_value is None:
+            logger.warning("환경변수 %s 를 찾을 수 없습니다.", env_key)
+            return None
+        return env_value
+    return text
 
 
 @dataclass(frozen=True)
@@ -55,13 +53,6 @@ class RerankerConfig:
 
 
 @dataclass(frozen=True)
-class ConfidenceConfig:
-    min_score: float
-    min_score_normalized: float
-    min_hits: int
-
-
-@dataclass(frozen=True)
 class EmbeddingConfig:
     provider: str
     model_name: str
@@ -77,7 +68,6 @@ class RetrievalConfig:
     chunk: ChunkConfig
     vectorstore: VectorStoreConfig
     reranker: RerankerConfig
-    confidence: ConfidenceConfig
     embedding: EmbeddingConfig
 
     @classmethod
@@ -85,7 +75,6 @@ class RetrievalConfig:
         chunk_payload = payload.get("chunk", {})
         vectorstore_payload = payload.get("vectorstore", {})
         reranker_payload = payload.get("reranker", {})
-        confidence_payload = payload.get("confidence", {})
         embedding_payload = payload.get("embedding", {})
 
         chunk = ChunkConfig(
@@ -101,29 +90,24 @@ class RetrievalConfig:
             top_k=int(reranker_payload.get("top_k", 5)),
             score_key=str(reranker_payload.get("score_key", "score")),
         )
-        confidence = ConfidenceConfig(
-            min_score=float(confidence_payload.get("min_score", 0.0)),
-            min_score_normalized=float(confidence_payload.get("min_score_normalized", 0.0)),
-            min_hits=int(confidence_payload.get("min_hits", 0)),
-        )
         embedding = EmbeddingConfig(
             provider=str(embedding_payload.get("provider", "upstage")),
-            model_name=str(embedding_payload.get("model_name", "solar-embedding-1-large-query")),
+            model_name=str(
+                embedding_payload.get(
+                    "model_name",
+                    "solar-embedding-1-large-query",
+                )
+            ),
             batch_size=int(embedding_payload.get("batch_size", 16)),
-            device=str(embedding_payload.get("device")) if embedding_payload.get("device") else None,
-            api_base=_resolve_env(embedding_payload.get("api_base")),
-            api_key=_resolve_env(embedding_payload.get("api_key")) or None,
+            device=_optional_str(embedding_payload.get("device")),
+            api_base=_optional_str(embedding_payload.get("api_base")),
+            api_key=_optional_str(embedding_payload.get("api_key")),
             timeout=float(embedding_payload.get("timeout", 15)),
         )
-        if isinstance(embedding.api_base, dict):
-            raise TypeError("api_base는 문자열이어야 합니다.")
-        if isinstance(embedding.api_key, dict):
-            raise TypeError("api_key는 문자열이어야 합니다.")
         return cls(
             chunk=chunk,
             vectorstore=vectorstore,
             reranker=reranker,
-            confidence=confidence,
             embedding=embedding,
         )
 
@@ -144,7 +128,6 @@ __all__ = [
     "ChunkConfig",
     "VectorStoreConfig",
     "RerankerConfig",
-    "ConfidenceConfig",
     "EmbeddingConfig",
     "RetrievalConfig",
     "load_retrieval_config",

--- a/src/retrieval/config.py
+++ b/src/retrieval/config.py
@@ -3,12 +3,36 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
+import os
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 _DEFAULT_CONFIG_PATH = Path("config/retrieval.yaml")
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_env(value: Any) -> Any:
+    if isinstance(value, str):
+        text = value.strip()
+        if text.startswith("${") and text.endswith("}"):
+            env_key = text[2:-1].strip()
+            if not env_key:
+                return ""
+            env_value = os.getenv(env_key)
+            if env_value is None:
+                logger.warning("환경변수 %s 를 찾을 수 없습니다.", env_key)
+                return ""
+            return env_value
+        return text
+    if isinstance(value, dict):
+        return {key: _resolve_env(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_resolve_env(item) for item in value]
+    return value
 
 
 @dataclass(frozen=True)
@@ -38,11 +62,23 @@ class ConfidenceConfig:
 
 
 @dataclass(frozen=True)
+class EmbeddingConfig:
+    provider: str
+    model_name: str
+    batch_size: int
+    device: str | None
+    api_base: str | None
+    api_key: str | None
+    timeout: float
+
+
+@dataclass(frozen=True)
 class RetrievalConfig:
     chunk: ChunkConfig
     vectorstore: VectorStoreConfig
     reranker: RerankerConfig
     confidence: ConfidenceConfig
+    embedding: EmbeddingConfig
 
     @classmethod
     def from_mapping(cls, payload: dict[str, Any]) -> "RetrievalConfig":
@@ -50,6 +86,7 @@ class RetrievalConfig:
         vectorstore_payload = payload.get("vectorstore", {})
         reranker_payload = payload.get("reranker", {})
         confidence_payload = payload.get("confidence", {})
+        embedding_payload = payload.get("embedding", {})
 
         chunk = ChunkConfig(
             size=int(chunk_payload.get("size", 800)),
@@ -69,7 +106,26 @@ class RetrievalConfig:
             min_score_normalized=float(confidence_payload.get("min_score_normalized", 0.0)),
             min_hits=int(confidence_payload.get("min_hits", 0)),
         )
-        return cls(chunk=chunk, vectorstore=vectorstore, reranker=reranker, confidence=confidence)
+        embedding = EmbeddingConfig(
+            provider=str(embedding_payload.get("provider", "upstage")),
+            model_name=str(embedding_payload.get("model_name", "solar-embedding-1-large-query")),
+            batch_size=int(embedding_payload.get("batch_size", 16)),
+            device=str(embedding_payload.get("device")) if embedding_payload.get("device") else None,
+            api_base=_resolve_env(embedding_payload.get("api_base")),
+            api_key=_resolve_env(embedding_payload.get("api_key")) or None,
+            timeout=float(embedding_payload.get("timeout", 15)),
+        )
+        if isinstance(embedding.api_base, dict):
+            raise TypeError("api_base는 문자열이어야 합니다.")
+        if isinstance(embedding.api_key, dict):
+            raise TypeError("api_key는 문자열이어야 합니다.")
+        return cls(
+            chunk=chunk,
+            vectorstore=vectorstore,
+            reranker=reranker,
+            confidence=confidence,
+            embedding=embedding,
+        )
 
 
 def load_retrieval_config(path: Path | str | None = None) -> RetrievalConfig:
@@ -89,6 +145,7 @@ __all__ = [
     "VectorStoreConfig",
     "RerankerConfig",
     "ConfidenceConfig",
+    "EmbeddingConfig",
     "RetrievalConfig",
     "load_retrieval_config",
 ]

--- a/src/retrieval/pipeline.py
+++ b/src/retrieval/pipeline.py
@@ -259,6 +259,9 @@ def _build_candidates(response: dict[str, Any]) -> list[dict[str, Any]]:
     metadatas = _first(response.get("metadatas"))
     distances = _first(response.get("distances"))
 
+    if not ids and documents:
+        ids = [f"doc-{index}" for index, _ in enumerate(documents)]
+
     if not ids:
         return []
 

--- a/src/websearch/config.py
+++ b/src/websearch/config.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +12,28 @@ import yaml
 
 _DEFAULT_CONFIG_PATH = Path("config/websearch.yaml")
 _DEFAULT_WHITELIST_PATH = Path("src/websearch/whitelist.yaml")
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_env(value: Any) -> Any:
+    if isinstance(value, str):
+        text = value.strip()
+        if text.startswith("${") and text.endswith("}" ):
+            env_key = text[2:-1].strip()
+            if not env_key:
+                return ""
+            env_value = os.getenv(env_key)
+            if env_value is None:
+                logger.warning("환경변수 %s 를 찾을 수 없습니다.", env_key)
+                return ""
+            return env_value
+        return text
+    if isinstance(value, dict):
+        return {key: _resolve_env(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_resolve_env(item) for item in value]
+    return value
 
 
 @dataclass(frozen=True)
@@ -20,7 +44,18 @@ class CacheConfig:
 
 @dataclass(frozen=True)
 class ProviderConfig:
+    base_url: str
+    method: str
+    query_param: str | None
+    payload: str
+    params: dict[str, Any]
+    headers: dict[str, str]
+    timeout: float
     max_results: int
+    response_items_path: tuple[str, ...]
+    response_title_field: str
+    response_url_field: str
+    response_snippet_field: str | None
 
 
 @dataclass(frozen=True)
@@ -38,8 +73,37 @@ class WebSearchConfig:
             directory=Path(cache_payload.get("directory", "data/web_cache")),
             ttl_seconds=int(cache_payload.get("ttl_seconds", 86_400)),
         )
+        base_url_raw = provider_payload.get("base_url", "https://api.example.com/search")
+        method = str(provider_payload.get("method", "GET")).upper()
+        query_param = provider_payload.get("query_param")
+        payload_mode = str(provider_payload.get("payload", "params")).lower()
+        params = _resolve_env(provider_payload.get("params", {}))
+        headers_resolved = _resolve_env(provider_payload.get("headers", {}))
+        headers = {str(key): str(value) for key, value in headers_resolved.items()}
+
+        response_payload = provider_payload.get("response", {})
+        items_path_raw = response_payload.get("items_path", [])
+        if isinstance(items_path_raw, str):
+            items_path = tuple(part for part in items_path_raw.split(".") if part)
+        else:
+            items_path = tuple(str(part) for part in items_path_raw)
         provider = ProviderConfig(
+            base_url=str(_resolve_env(base_url_raw)),
+            method=method,
+            query_param=str(query_param) if query_param is not None else None,
+            payload=payload_mode,
+            params=params if isinstance(params, dict) else {},
+            headers=headers,
+            timeout=float(provider_payload.get("timeout", 8)),
             max_results=int(provider_payload.get("max_results", 5)),
+            response_items_path=items_path,
+            response_title_field=str(response_payload.get("title_field", "title")),
+            response_url_field=str(response_payload.get("url_field", "url")),
+            response_snippet_field=(
+                str(response_payload.get("snippet_field"))
+                if response_payload.get("snippet_field") is not None
+                else None
+            ),
         )
         lookup = payload.get("whitelist_path")
         whitelist_path = Path(lookup) if lookup else _DEFAULT_WHITELIST_PATH

--- a/src/websearch/provider.py
+++ b/src/websearch/provider.py
@@ -1,0 +1,103 @@
+"""웹 검색 Provider 구현."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import requests
+
+from src.websearch.config import ProviderConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _deep_get(payload: dict[str, Any], dotted: str | None) -> Any:
+    if not dotted:
+        return None
+    current: Any = payload
+    for part in dotted.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _select_items(payload: Any, items_path: tuple[str, ...]) -> list[Any]:
+    current = payload
+    for key in items_path:
+        if isinstance(current, dict):
+            current = current.get(key)
+        else:
+            return []
+    if isinstance(current, list):
+        return current
+    logger.debug("items_path 결과가 list가 아님: %s", current)
+    return []
+
+
+@dataclass
+class RequestsSearchProvider:
+    config: ProviderConfig
+    session: requests.Session = field(default_factory=requests.Session)
+
+    def __post_init__(self) -> None:
+        if self.config.headers:
+            self.session.headers.update(self.config.headers)
+
+    def __call__(self, *, query: str, max_results: int) -> list[dict[str, Any]]:
+        limit = min(max_results, self.config.max_results)
+        if limit <= 0:
+            return []
+
+        params = dict(self.config.params)
+        if self.config.query_param:
+            params[self.config.query_param] = query
+
+        request_kwargs: dict[str, Any] = {"timeout": self.config.timeout}
+        if self.config.payload == "json":
+            request_kwargs["json"] = params
+        else:
+            request_kwargs["params"] = params
+
+        try:
+            response = self.session.request(
+                self.config.method,
+                self.config.base_url,
+                **request_kwargs,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.error("웹 검색 API 호출 실패: %s", exc)
+            return []
+
+        items = _select_items(payload, self.config.response_items_path)
+        results: list[dict[str, Any]] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            title = _deep_get(item, self.config.response_title_field)
+            url = _deep_get(item, self.config.response_url_field)
+            snippet_field = self.config.response_snippet_field
+            snippet = _deep_get(item, snippet_field) if snippet_field else None
+            if not isinstance(url, str) or not url:
+                continue
+            result = {
+                "title": title if isinstance(title, str) else None,
+                "url": url,
+                "snippet": snippet if isinstance(snippet, str) else None,
+                "raw": item,
+            }
+            results.append(result)
+            if len(results) >= limit:
+                break
+        return results
+
+
+def create_requests_provider(config: ProviderConfig) -> RequestsSearchProvider:
+    return RequestsSearchProvider(config=config)
+
+
+__all__ = ["RequestsSearchProvider", "create_requests_provider"]

--- a/src/websearch/search.py
+++ b/src/websearch/search.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 import yaml
 
 from src.websearch.config import WebSearchConfig, load_websearch_config
+from src.websearch.provider import create_requests_provider
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +57,7 @@ def search_web(
         logger.debug("웹 검색 캐시 적중: %s", cache_path)
         return cached
 
-    if provider is None:
-        raise RuntimeError("검색 provider가 설정되지 않았습니다. search_web 호출 시 provider를 주입하세요.")
+    provider = provider or create_requests_provider(config.provider)
 
     results = provider(query=query, max_results=config.provider.max_results)
     filtered = _filter_whitelist(results, config)

--- a/tests/unit/test_pipeline_smoke.py
+++ b/tests/unit/test_pipeline_smoke.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.retrieval.config import RetrievalConfig, load_retrieval_config
+from src.retrieval.pipeline import RetrievalPipeline
+
+
+def test_pipeline_ingest_smoke(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    output_dir = tmp_path / "processed"
+    raw_dir.mkdir()
+    output_dir.mkdir()
+
+    (raw_dir / "sample.txt").write_text("이것은 대출 한도에 대한 안내 문서입니다.", encoding="utf-8")
+
+    base_config: RetrievalConfig = load_retrieval_config()
+    vectorstore_path = tmp_path / "chroma"
+    vectorstore = replace(base_config.vectorstore, persist_directory=vectorstore_path)
+    config = replace(base_config, vectorstore=vectorstore)
+
+    pipeline = RetrievalPipeline(config=config)
+    result = pipeline.ingest(
+        raw_dir=raw_dir,
+        output_dir=output_dir,
+        chunk_filename="chunks.jsonl",
+        document_filename="documents.json",
+        persist_outputs=True,
+        skip_vectorstore=False,
+    )
+
+    assert result.documents, "최소 한 개의 문서는 처리되어야 합니다."
+    assert result.upserted >= 1, "벡터스토어 업서트가 수행되어야 합니다."
+    assert (output_dir / "chunks.jsonl").exists()
+    assert (output_dir / "documents.json").exists()

--- a/tests/unit/test_websearch.py
+++ b/tests/unit/test_websearch.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+import sys
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.websearch.config import CacheConfig, ProviderConfig, WebSearchConfig
+from src.websearch.provider import RequestsSearchProvider
+from src.websearch.search import search_web
+
+
+@pytest.fixture()
+def whitelist_file(tmp_path: Path) -> Path:
+    path = tmp_path / "whitelist.yaml"
+    path.write_text("domains:\n  - domain: example.com\n")
+    return path
+
+
+def make_config(
+    tmp_path: Path,
+    whitelist: Path,
+    ttl: int = 3600,
+    items_path: tuple[str, ...] = (),
+) -> WebSearchConfig:
+    cache = CacheConfig(directory=tmp_path, ttl_seconds=ttl)
+    provider = ProviderConfig(
+        base_url="https://api.example.com/search",
+        method="GET",
+        query_param="q",
+        payload="params",
+        params={},
+        headers={},
+        timeout=2.0,
+        max_results=5,
+        response_items_path=items_path,
+        response_title_field="title",
+        response_url_field="url",
+        response_snippet_field="snippet",
+    )
+    return WebSearchConfig(cache=cache, provider=provider, whitelist_path=whitelist)
+
+
+def test_search_cache_hits_within_ttl(tmp_path: Path, whitelist_file: Path) -> None:
+    config = make_config(tmp_path, whitelist_file, items_path=("data", "results"))
+    calls: list[str] = []
+
+    def provider(*, query: str, max_results: int) -> list[dict[str, Any]]:
+        calls.append(query)
+        return [
+            {
+                "title": "Example",
+                "url": "https://example.com/article",
+                "snippet": "snippet",
+            }
+        ]
+
+    results_first = search_web("대출", provider=provider, config=config)
+    results_second = search_web("대출", provider=provider, config=config)
+
+    assert len(results_first) == 1
+    assert results_second == results_first
+    assert len(calls) == 1, "캐시 재사용 시 provider가 재호출되지 않아야 합니다."
+
+
+def test_search_cache_expires(tmp_path: Path, whitelist_file: Path) -> None:
+    config = make_config(tmp_path, whitelist_file, ttl=0)
+    calls: list[str] = []
+
+    def provider(*, query: str, max_results: int) -> list[dict[str, Any]]:
+        calls.append(query)
+        return [
+            {
+                "title": "Example",
+                "url": "https://example.com/article",
+                "snippet": "snippet",
+            }
+        ]
+
+    search_web("금리", provider=provider, config=config)
+    search_web("금리", provider=provider, config=config)
+
+    assert len(calls) == 2, "TTL이 만료되면 provider가 다시 호출되어야 합니다."
+
+
+def test_whitelist_filters_results(tmp_path: Path) -> None:
+    whitelist = tmp_path / "whitelist.yaml"
+    whitelist.write_text(
+        "domains:\n  - domain: example.com\n    paths:\n      - /allowed\n"
+    )
+    config = make_config(tmp_path, whitelist)
+
+    def provider(*, query: str, max_results: int) -> list[dict[str, Any]]:
+        return [
+            {"title": "allow", "url": "https://example.com/allowed/1", "snippet": "ok"},
+            {"title": "deny", "url": "https://example.com/other/2", "snippet": "no"},
+            {"title": "deny-domain", "url": "https://bad.com/news", "snippet": "bad"},
+        ]
+
+    results = search_web("테스트", provider=provider, config=config)
+    assert len(results) == 1
+    assert results[0]["url"].startswith("https://example.com/allowed")
+
+
+def test_requests_provider_maps_response(tmp_path: Path, whitelist_file: Path) -> None:
+    config = make_config(tmp_path, whitelist_file, items_path=("data", "results"))
+
+    provider = RequestsSearchProvider(config.provider)
+
+    class DummyResponse:
+        def __init__(self, payload: dict[str, Any]) -> None:
+            self._payload = payload
+
+        def json(self) -> dict[str, Any]:
+            return self._payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def request(self, method: str, url: str, **kwargs: Any) -> DummyResponse:
+            self.calls.append({"method": method, "url": url, **kwargs})
+            payload = {
+                "data": {
+                    "results": [
+                        {
+                            "title": "Example Title",
+                            "url": "https://example.com/allowed/123",
+                            "snippet": "Example snippet",
+                        }
+                    ]
+                }
+            }
+            return DummyResponse(payload)
+
+    dummy_session = DummySession()
+    provider.session = dummy_session  # type: ignore[assignment]
+
+    results = provider(query="테스트", max_results=3)
+    assert len(results) == 1
+    assert results[0]["url"] == "https://example.com/allowed/123"
+    assert dummy_session.calls, "요청이 발생해야 합니다."


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
   1. SearchProvider 프로토콜을 만족하는 기본 구현 작성 
   2. config/websearch.yaml에 base URL, 키, 응답 필드를 정의하고 WebSearchConfig 확장.
   3. 캐시 TTL, 화이트리스트 규칙 검증 테스트 추가.
   4. scripts/build_index.py, scripts/refresh_kb.py, scripts/evaluate_reranker.py에서 RetrievalPipeline을 호
    출하고 필요한 옵션을 주입.
   5. Typer CLI(scripts/cli.py)에서 build_index, refresh_kb, evaluate 명령이 실제 파일을 생성·갱신·평가하도록
    구현.
   6. ingest/업서트 후 결과 검증용 테스트 또는 스모크 스크립트 작성.
<br>

## 📌Issue
> 닫을 issue 번호 : resolved #40

<br>

## 🩼Branch
> 반영 branch feat-40 -> dev

<br>

## 👪To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.
