### PR TITLE
챗봇 근거/문서 섹션 제거

### DIFF
--- a/config/prompts/composer_answer.txt
+++ b/config/prompts/composer_answer.txt
@@ -1,5 +1,5 @@
 # 응답 조립(composer) 프롬프트
-# - 정보형: 내부 문서 요약 → 웹 검색 보강 → 출처 링크 → 주의사항 순으로 구성하세요.
+# - 정보형: 핵심 요약과 신뢰도, 주의 문구를 간결하게 제공합니다.
 # - 계산형: 계산 가정/결과/정책/상환 요약을 카드 형태로 제시하고 면책 문구를 포함하세요.
 # - 응답은 Markdown을 사용하며 bullet과 굵은 텍스트를 적절히 배치하세요.
 
@@ -30,30 +30,11 @@
 - 가정: 없음
 {% endif %}
 
-**출처**
-{% for src in calc.sources %}- {{ src }}
-{% else %}- 계산 엔진 산출 결과 기준
-{% endfor %}
-
 > 본 결과는 참고용이며 실제 한도와 금리는 금융기관 심사 결과에 따라 달라질 수 있습니다. 최신 심사 기준은 취급 금융기관에 확인하세요.
 
 {% else %}
 **요약**
 {{ summary | truncate(350, True, '...') }}
-
-{% if info.documents %}
-**내부 문서**
-{% for item in info.documents[:5] %}
-- {% if item.url %}[{{ item.title }}]({{ item.url }}){% else %}{{ item.title }}{% endif %}{% if item.snippet %}: {{ item.snippet | truncate(160, True, '...') }}{% endif %}
-{% endfor %}
-{% endif %}
-
-{% if info.web %}
-**웹 검색 보강**
-{% for item in info.web[:3] %}
-- {% if item.url %}[{{ item.title }}]({{ item.url }}){% else %}{{ item.title }}{% endif %}{% if item.snippet %}: {{ item.snippet | truncate(140, True, '...') }}{% endif %}
-{% endfor %}
-{% endif %}
 
 {% if confidence %}
 **신뢰도**
@@ -64,13 +45,6 @@
 - 점수: -
 - 사유: (표시할 데이터 없음)
 {% endif %}
-
-**출처 목록**
-{% for src in info.sources %}
-- {{ src }}
-{% else %}
-- 일치하는 내부 문서가 부족하여 요약 정보만 제공합니다.
-{% endfor %}
 
 > 실제 취급 조건은 금융기관 심사와 약관에 따라 달라질 수 있습니다. 최신 공시일이 12개월 이상 지났다면 업데이트가 필요합니다.
 {% endif %}

--- a/src/orchestration/composer.py
+++ b/src/orchestration/composer.py
@@ -17,6 +17,7 @@ def _find_prompts_dir() -> Path:
         here.parents[2] / "prompts",   # 프로젝트 루트/prompts (권장)
         here.parents[1] / "prompts",   # src/prompts
         here.parent / "prompts",       # orchestration/prompts
+        here.parents[2] / "config" / "prompts",  # config/prompts (운영 설정)
     ]
     for p in candidates:
         if p.exists():
@@ -42,33 +43,9 @@ _FALLBACK = """\
 {% if calc.assumptions %}
 가정: {{ calc.assumptions | join(", ") }}
 {% endif %}
-{% if calc.sources %}
-근거:
-{% for src in calc.sources %}
-- {{ src }}
-{% endfor %}
-{% endif %}
 {% else -%}
 정보 요약
 {{ summary }}
-{% if info.documents %}
-내부 문서
-{% for item in info.documents %}
-- {{ item.title }}{% if item.snippet %}: {{ item.snippet }}{% endif %}{% if item.url %} ({{ item.url }}){% endif %}
-{% endfor %}
-{% endif %}
-{% if info.web %}
-웹 검색
-{% for item in info.web %}
-- {{ item.title }}{% if item.snippet %}: {{ item.snippet }}{% endif %}{% if item.url %} ({{ item.url }}){% endif %}
-{% endfor %}
-{% endif %}
-{% if info.sources %}
-근거
-{% for src in info.sources %}
-- {{ src }}
-{% endfor %}
-{% endif %}
 {% if confidence %}
 {% set passed = confidence.get("passed") if confidence is mapping else None %}
 {% set score = confidence.get("score") if confidence is mapping else None %}
@@ -128,8 +105,12 @@ def _summarize_documents(documents: Iterable[dict[str, Any]]) -> list[dict[str, 
             title = title or metadata.get("doc_title") or metadata.get("title")
             url = url or metadata.get("url") or metadata.get("doc_source")
             snippet = snippet or metadata.get("snippet")
+        if not title and snippet:
+            title = _truncate(str(snippet))
+        if not title and url:
+            title = str(url)
         if not title:
-            title = f"문서 {idx + 1}"
+            continue
         if snippet:
             snippet = _truncate(str(snippet))
         if url:


### PR DESCRIPTION
## ⭐Key Changes

 src/orchestration/composer.py:31-125 – 폴백 템플릿과 문서 요약 로직에서 근거/문서 섹션을 제거하고
    제목 없이 번호가 붙지 않도록 수정.
  - config/prompts/composer_answer.txt:1-49 – 메인 컴포저 프롬프트에서 근거·내부 문서·웹 검색 출력 블
    록을 삭제해 정보형/계산형 답변이 번호와 링크를 노출하지 않도록 조정.

<br>

## 🩼Branch
> 반영 branch feat-56 -> dev

