### PR TITLE
DSR 한도 분기, 금액 단위 파싱, 정보형 질문 분류 로직 수정

### DIFF
--- a/src/api/schemas/calc.py
+++ b/src/api/schemas/calc.py
@@ -16,6 +16,7 @@ class CalcType(str, Enum):
     DSR = "dsr"
     AMORTIZATION = "amortization"
     PAYMENT_SENSITIVITY = "payment_sensitivity"
+    PREPAYMENT_FEE = "prepayment_fee"
 
 
 class CalcRequest(BaseModel):

--- a/src/nlp/slot_intent.py
+++ b/src/nlp/slot_intent.py
@@ -49,6 +49,16 @@ _INFO_KEYWORDS = {
 }
 _QUESTION_TOKENS = {"?", "어떻게", "왜", "언제", "어디", "무엇"}
 
+_INCOME_KEYWORDS = ("연소득", "연 봉", "연봉", "연간소득", "소득")
+_DEBT_KEYWORDS = ("부채", "상환")
+_COLLATERAL_KEYWORDS = ("집값", "주택가격", "주택 가격", "담보", "시세", "매매가", "아파트값")
+_LOAN_KEYWORDS = ("대출", "대출금", "대출액", "원금", "잔금", "대출잔액", "잔액")
+_MONTH_KEYWORDS = ("월", "매월", "월별")
+_RATE_INTEREST_KEYWORDS = ("금리", "이자", "연이율", "연 이자율")
+_RATE_DSR_KEYWORDS = ("dsr", "디에스알")
+_RATE_DTI_KEYWORDS = ("dti", "디티아이")
+_RATE_LTV_KEYWORDS = ("ltv", "담보비율", "담보 비율", "담보인정", "담보 인정")
+
 _AMOUNT_PATTERN = re.compile(r"(?P<num>\d[\d,\.]*)\s*(?P<unit>억|만|천|백)?\s*(?P<currency>원|만원|억원)?")
 _RATE_PATTERN = re.compile(r"(?P<rate>\d+(?:\.\d+)?)\s*%")
 _TERM_YEAR_PATTERN = re.compile(r"(?P<years>\d+)\s*년")
@@ -140,7 +150,82 @@ def _rule_based_analysis(message: str) -> RuleAnalysis:
 def _extract_slots(message: str) -> Dict[str, Any]:
     slots: Dict[str, Any] = {}
 
+    def _context_before(span: tuple[int, int], window: int = 12) -> str:
+        start = max(0, span[0] - window)
+        return message[start:span[0]].lower()
+
+    def _context_after(span: tuple[int, int], window: int = 12) -> str:
+        end = min(len(message), span[1] + window)
+        return message[span[1]:end].lower()
+
+    def _contains_any(text: str, keywords: tuple[str, ...]) -> bool:
+        return any(keyword in text for keyword in keywords)
+
+    rate_matches = list(_RATE_PATTERN.finditer(message))
+    rate_spans: list[tuple[int, int]] = []
+    interest_assigned = False
+
+    for match in rate_matches:
+        span = match.span()
+        rate_spans.append(span)
+        try:
+            value = float(match.group("rate"))
+        except (TypeError, ValueError):
+            continue
+        before = _context_before(span)
+        after = _context_after(span)
+        if _contains_any(before, _RATE_DSR_KEYWORDS):
+            slots.setdefault("target_dsr", value)
+            slots.setdefault("target_dsr_unit", "percent")
+            continue
+        if _contains_any(before, _RATE_DTI_KEYWORDS):
+            slots.setdefault("target_dti", value)
+            slots.setdefault("target_dti_unit", "percent")
+            continue
+        if _contains_any(before, _RATE_LTV_KEYWORDS):
+            slots.setdefault("target_ltv", value)
+            slots.setdefault("target_ltv_unit", "percent")
+            continue
+        if not interest_assigned and (_contains_any(before, _RATE_INTEREST_KEYWORDS) or _contains_any(after, _RATE_INTEREST_KEYWORDS)):
+            slots["interest_rate"] = value
+            slots.setdefault("interest_rate_unit", "percent")
+            interest_assigned = True
+            continue
+        if not interest_assigned:
+            slots["interest_rate"] = value
+            slots.setdefault("interest_rate_unit", "percent")
+            interest_assigned = True
+        else:
+            slots.setdefault("additional_rates", []).append(value)
+
+    year_matches = list(_TERM_YEAR_PATTERN.finditer(message))
+    month_matches = list(_TERM_MONTH_PATTERN.finditer(message))
+    term_spans = [match.span() for match in year_matches]
+    term_spans.extend(match.span() for match in month_matches)
+
+    term_months = 0
+    for match in year_matches:
+        try:
+            term_months += int(match.group("years")) * 12
+        except (TypeError, ValueError):
+            continue
+    for match in month_matches:
+        try:
+            term_months += int(match.group("months"))
+        except (TypeError, ValueError):
+            continue
+    if term_months:
+        slots["term_months"] = term_months
+
+    skip_spans = rate_spans + term_spans
+
+    def _overlaps(target: tuple[int, int], span: tuple[int, int]) -> bool:
+        return target[0] < span[1] and span[0] < target[1]
+
     for match in _AMOUNT_PATTERN.finditer(message):
+        span = match.span()
+        if any(_overlaps(span, other) for other in skip_spans):
+            continue
         raw = match.group("num")
         unit = match.group("unit")
         currency = match.group("currency")
@@ -152,29 +237,40 @@ def _extract_slots(message: str) -> Dict[str, Any]:
             continue
         if not normalized:
             continue
-        if "loan_amount" not in slots:
-            slots["loan_amount"] = normalized
-        else:
-            slots.setdefault("additional_amounts", []).append(normalized)
+        context = (message[max(0, span[0] - 12): min(len(message), span[1] + 12)]).lower()
+        assigned = False
+
+        if _contains_any(context, _INCOME_KEYWORDS):
+            slots.setdefault("annual_income", normalized)
+            assigned = True
+        elif _contains_any(context, _DEBT_KEYWORDS):
+            if _contains_any(context, _MONTH_KEYWORDS):
+                slots.setdefault("monthly_debt_payment", normalized)
+                slots.setdefault("annual_debt_service", normalized * 12)
+            else:
+                slots.setdefault("annual_debt_service", normalized)
+            assigned = True
+        elif _contains_any(context, _COLLATERAL_KEYWORDS):
+            if "collateral_value" not in slots:
+                slots["collateral_value"] = normalized
+            else:
+                slots.setdefault("additional_amounts", []).append(normalized)
+            assigned = True
+        elif _contains_any(context, _LOAN_KEYWORDS):
+            if "loan_amount" not in slots:
+                slots["loan_amount"] = normalized
+            else:
+                slots.setdefault("additional_amounts", []).append(normalized)
+            assigned = True
+
+        if not assigned:
+            if "loan_amount" not in slots:
+                slots["loan_amount"] = normalized
+            else:
+                slots.setdefault("additional_amounts", []).append(normalized)
+
         if currency and "currency" not in slots:
             slots["currency"] = currency
-
-    rate_match = _RATE_PATTERN.search(message)
-    if rate_match:
-        try:
-            slots["interest_rate"] = float(rate_match.group("rate"))
-        except (TypeError, ValueError):
-            pass
-
-    years_match = _TERM_YEAR_PATTERN.search(message)
-    months_match = _TERM_MONTH_PATTERN.search(message)
-    term_months: Optional[int] = None
-    if years_match:
-        term_months = int(years_match.group("years")) * 12
-    if months_match:
-        term_months = (term_months or 0) + int(months_match.group("months"))
-    if term_months:
-        slots["term_months"] = term_months
 
     return slots
 

--- a/src/nlp/slot_intent.py
+++ b/src/nlp/slot_intent.py
@@ -58,11 +58,101 @@ _RATE_INTEREST_KEYWORDS = ("금리", "이자", "연이율", "연 이자율")
 _RATE_DSR_KEYWORDS = ("dsr", "디에스알")
 _RATE_DTI_KEYWORDS = ("dti", "디티아이")
 _RATE_LTV_KEYWORDS = ("ltv", "담보비율", "담보 비율", "담보인정", "담보 인정")
+_RATE_PREPAYMENT_KEYWORDS = ("중도상환", "수수료")
 
-_AMOUNT_PATTERN = re.compile(r"(?P<num>\d[\d,\.]*)\s*(?P<unit>억|만|천|백)?\s*(?P<currency>원|만원|억원)?")
+
+def _iter_amount_spans(message: str) -> list[tuple[int, int, str]]:
+    spans: list[tuple[int, int, str]] = []
+    length = len(message)
+    index = 0
+    while index < length:
+        char = message[index]
+        if char.isdigit():
+            start = index
+            last_valid = index + 1
+            index += 1
+            while index < length:
+                current = message[index]
+                if current.isdigit() or current in {",", "."}:
+                    last_valid = index + 1
+                    index += 1
+                    continue
+                if current.isspace():
+                    index += 1
+                    continue
+                if current in _AMOUNT_UNIT_CHARS:
+                    last_valid = index + 1
+                    index += 1
+                    continue
+                break
+            if last_valid > start:
+                spans.append((start, last_valid, message[start:last_valid]))
+            index = last_valid
+        else:
+            index += 1
+    # remove duplicates
+    unique: dict[tuple[int, int], str] = {}
+    for start, end, token in spans:
+        unique.setdefault((start, end), token)
+    ordered = sorted(unique.items(), key=lambda item: item[0][0])
+    return [(start, end, token) for (start, end), token in ordered]
+
+
+def _parse_basic_number(fragment: str) -> float:
+    fragment = fragment.strip()
+    if not fragment:
+        return 1.0
+    try:
+        return float(fragment)
+    except ValueError:
+        pass
+    total = 0.0
+    remaining = fragment
+    for unit, multiplier in (("천", 1000.0), ("백", 100.0), ("십", 10.0)):
+        while unit in remaining:
+            idx = remaining.find(unit)
+            head = remaining[:idx]
+            number = float(head) if head else 1.0
+            total += number * multiplier
+            remaining = remaining[idx + len(unit) :]
+    if remaining:
+        try:
+            total += float(remaining)
+        except ValueError:
+            pass
+    return total
+
+
+def _normalize_amount_token(raw: str) -> Optional[int]:
+    cleaned = raw.replace(",", "").replace(" ", "").strip()
+    if cleaned.endswith("원"):
+        cleaned = cleaned[: -len("원")]
+    if not cleaned:
+        return None
+
+    total = 0.0
+    remaining = cleaned
+
+    for unit, multiplier in (("억", 100_000_000.0), ("만", 10_000.0)):
+        while unit in remaining:
+            idx = remaining.find(unit)
+            head = remaining[:idx]
+            part = _parse_basic_number(head)
+            total += part * multiplier
+            remaining = remaining[idx + len(unit) :]
+
+    if remaining:
+        total += _parse_basic_number(remaining)
+
+    if total <= 0:
+        return None
+    return int(round(total))
+
 _RATE_PATTERN = re.compile(r"(?P<rate>\d+(?:\.\d+)?)\s*%")
 _TERM_YEAR_PATTERN = re.compile(r"(?P<years>\d+)\s*년")
 _TERM_MONTH_PATTERN = re.compile(r"(?P<months>\d+)\s*개월?")
+
+_AMOUNT_UNIT_CHARS = {"억", "만", "천", "백", "십", "원"}
 
 
 class LLMClient(Protocol):
@@ -186,6 +276,10 @@ def _extract_slots(message: str) -> Dict[str, Any]:
             slots.setdefault("target_ltv", value)
             slots.setdefault("target_ltv_unit", "percent")
             continue
+        if _contains_any(before, _RATE_PREPAYMENT_KEYWORDS) or _contains_any(after, _RATE_PREPAYMENT_KEYWORDS):
+            slots.setdefault("fee_rate", value)
+            slots.setdefault("fee_rate_unit", "percent")
+            continue
         if not interest_assigned and (_contains_any(before, _RATE_INTEREST_KEYWORDS) or _contains_any(after, _RATE_INTEREST_KEYWORDS)):
             slots["interest_rate"] = value
             slots.setdefault("interest_rate_unit", "percent")
@@ -217,28 +311,36 @@ def _extract_slots(message: str) -> Dict[str, Any]:
     if term_months:
         slots["term_months"] = term_months
 
-    skip_spans = rate_spans + term_spans
+    skip_spans_set = {span for span in rate_spans + term_spans}
+    skip_spans = sorted(skip_spans_set)
 
     def _overlaps(target: tuple[int, int], span: tuple[int, int]) -> bool:
         return target[0] < span[1] and span[0] < target[1]
 
-    for match in _AMOUNT_PATTERN.finditer(message):
-        span = match.span()
+    for start, end, token in _iter_amount_spans(message):
+        span = (start, end)
         if any(_overlaps(span, other) for other in skip_spans):
             continue
-        raw = match.group("num")
-        unit = match.group("unit")
-        currency = match.group("currency")
-        if not raw:
-            continue
-        try:
-            normalized = _normalize_amount(raw, unit, currency)
-        except ValueError:
-            continue
-        if not normalized:
+        normalized = _normalize_amount_token(token)
+        if normalized is None:
             continue
         context = (message[max(0, span[0] - 12): min(len(message), span[1] + 12)]).lower()
+        before_word = message[max(0, span[0] - 12): span[0]].strip().lower().split()
+        after_word = message[span[1] : min(len(message), span[1] + 12)].strip().lower().split()
+        prev_token = before_word[-1] if before_word else ""
+        next_token = after_word[0] if after_word else ""
         assigned = False
+
+        loan_hit = (
+            _contains_any(context, _LOAN_KEYWORDS)
+            or prev_token in _LOAN_KEYWORDS
+            or next_token in _LOAN_KEYWORDS
+        )
+        collateral_hit = (
+            _contains_any(context, _COLLATERAL_KEYWORDS)
+            or prev_token in _COLLATERAL_KEYWORDS
+            or next_token in _COLLATERAL_KEYWORDS
+        )
 
         if _contains_any(context, _INCOME_KEYWORDS):
             slots.setdefault("annual_income", normalized)
@@ -250,54 +352,47 @@ def _extract_slots(message: str) -> Dict[str, Any]:
             else:
                 slots.setdefault("annual_debt_service", normalized)
             assigned = True
-        elif _contains_any(context, _COLLATERAL_KEYWORDS):
-            if "collateral_value" not in slots:
-                slots["collateral_value"] = normalized
-            else:
-                slots.setdefault("additional_amounts", []).append(normalized)
-            assigned = True
-        elif _contains_any(context, _LOAN_KEYWORDS):
-            if "loan_amount" not in slots:
-                slots["loan_amount"] = normalized
-            else:
-                slots.setdefault("additional_amounts", []).append(normalized)
+        elif "잔액" in context:
+            slots.setdefault("principal", normalized)
+            slots.setdefault("loan_amount", normalized)
             assigned = True
 
         if not assigned:
+            if loan_hit and not collateral_hit:
+                slots.setdefault("loan_amount", normalized)
+                slots.setdefault("principal", normalized)
+                assigned = True
+            elif collateral_hit and not loan_hit:
+                if "collateral_value" not in slots:
+                    slots["collateral_value"] = normalized
+                else:
+                    slots.setdefault("additional_amounts", []).append(normalized)
+                assigned = True
+            elif loan_hit and collateral_hit:
+                if prev_token in _COLLATERAL_KEYWORDS:
+                    if "collateral_value" not in slots:
+                        slots["collateral_value"] = normalized
+                    else:
+                        slots.setdefault("additional_amounts", []).append(normalized)
+                elif prev_token in _LOAN_KEYWORDS or next_token in _LOAN_KEYWORDS:
+                    slots.setdefault("loan_amount", normalized)
+                    slots.setdefault("principal", normalized)
+                else:
+                    if "collateral_value" not in slots:
+                        slots["collateral_value"] = normalized
+                    else:
+                        slots.setdefault("additional_amounts", []).append(normalized)
+                assigned = True
+
+        if not assigned:
             if "loan_amount" not in slots:
-                slots["loan_amount"] = normalized
+                slots.setdefault("loan_amount", normalized)
             else:
                 slots.setdefault("additional_amounts", []).append(normalized)
-
-        if currency and "currency" not in slots:
-            slots["currency"] = currency
+    if "additional_amounts" in slots:
+        slots["additional_amounts"] = sorted({int(value) for value in slots["additional_amounts"]}, reverse=True)
 
     return slots
-
-
-def _normalize_amount(raw: str, unit: Optional[str], currency: Optional[str] = None) -> Optional[int]:
-    cleaned = raw.replace(",", "")
-    try:
-        value = float(cleaned)
-    except ValueError as exc:  # noqa: BLE001
-        raise ValueError from exc
-
-    multiplier = 1.0
-    if unit == "억":
-        multiplier = 100_000_000.0
-    elif unit == "만":
-        multiplier = 10_000.0
-    elif unit == "천":
-        multiplier = 1_000.0
-    elif unit == "백":
-        multiplier = 100.0
-    elif not unit and currency in {"만원"}:
-        multiplier = 10_000.0
-    elif not unit and currency in {"억원"}:
-        multiplier = 100_000_000.0
-
-    normalized = int(value * multiplier)
-    return normalized if normalized > 0 else None
 
 
 def _call_llm_router(message: str, rule: RuleAnalysis) -> Optional[dict[str, Any]]:

--- a/src/services/chat_service.py
+++ b/src/services/chat_service.py
@@ -346,7 +346,11 @@ class ChatService:
             return build_chat_response(
                 intent=intent,
                 category=response_category,
-                data=compute_payload,
+                data=_normalize_calculational_payload(
+                    compute_payload,
+                    calc_type=calc_type,
+                    category=response_category,
+                ),
                 message=message,
                 generated_at=generated_at,
                 mock=getattr(self._compute, "is_mock", False),
@@ -936,6 +940,43 @@ def _build_compute_answer_message(
 
 def _humanize_param_name(name: str) -> str:
     return CALC_PARAM_LABELS.get(name, name)
+
+
+def _normalize_calculational_payload(
+    payload: dict[str, Any],
+    *,
+    calc_type: CalcType | None,
+    category: str | None,
+) -> dict[str, Any]:
+    normalized = dict(payload or {})
+
+    needs_input_value = normalized.get("needs_input")
+    normalized["needs_input"] = bool(needs_input_value)
+    normalized["need_inputs"] = normalized["needs_input"]
+
+    followups = normalized.get("followups")
+    if isinstance(followups, list):
+        normalized["followups"] = list(followups)
+    else:
+        normalized["followups"] = []
+
+    missing = normalized.get("missing_params")
+    if normalized["needs_input"]:
+        if not isinstance(missing, list):
+            normalized["missing_params"] = list(missing) if isinstance(missing, (list, tuple)) else []
+    else:
+        normalized["missing_params"] = []
+
+    if calc_type is not None:
+        normalized.setdefault("calc_type", calc_type.value)
+        normalized.setdefault("type", calc_type.value)
+    else:
+        normalized.setdefault("type", "calc")
+
+    if category:
+        normalized.setdefault("category", category)
+
+    return normalized
 
 
 def _normalize_calc_params(params: dict[str, Any], *, message: str | None = None) -> dict[str, Any]:

--- a/src/services/chat_service.py
+++ b/src/services/chat_service.py
@@ -506,7 +506,7 @@ def _prepare_calc_params(request: ChatRequest, resolution: IntentResolution) -> 
     if resolution.slots:
         for key, value in resolution.slots.items():
             params.setdefault(key, value)
-    return _normalize_calc_params(params)
+    return _normalize_calc_params(params, message=request.message)
 
 
 def _attach_intent_metadata(
@@ -921,7 +921,7 @@ def _humanize_param_name(name: str) -> str:
     return CALC_PARAM_LABELS.get(name, name)
 
 
-def _normalize_calc_params(params: dict[str, Any]) -> dict[str, Any]:
+def _normalize_calc_params(params: dict[str, Any], *, message: str | None = None) -> dict[str, Any]:
     normalized: dict[str, Any] = {}
     for key, value in params.items():
         if isinstance(value, str):
@@ -948,6 +948,8 @@ def _normalize_calc_params(params: dict[str, Any]) -> dict[str, Any]:
         _copy_if_missing("collateral_value", "property_value")
         _copy_if_missing("existing_debt_payment", "total_debt_payment")
         _copy_if_missing("total_debt_payment", "existing_debt_payment")
+        _copy_if_missing("annual_debt_service", "total_debt_payment")
+        _copy_if_missing("total_debt_payment", "annual_debt_service")
 
     _apply_aliases()
 
@@ -960,15 +962,24 @@ def _normalize_calc_params(params: dict[str, Any]) -> dict[str, Any]:
 
     _apply_aliases()
 
-    _fill_collateral_and_loan_amounts(normalized)
+    monthly_debt = _to_numeric(normalized.get("monthly_debt_payment"))
+    if monthly_debt is not None and _is_empty_value(normalized.get("annual_debt_service")):
+        normalized["annual_debt_service"] = int(round(monthly_debt * 12))
+
+    _apply_aliases()
+
+    _fill_collateral_and_loan_amounts(normalized, message=message)
 
     _apply_aliases()
 
     return normalized
 
 
-def _fill_collateral_and_loan_amounts(params: dict[str, Any]) -> None:
+def _fill_collateral_and_loan_amounts(params: dict[str, Any], *, message: str | None = None) -> None:
     """추출된 수치 정보를 활용해 담보 가치/대출 금액을 보완한다."""
+
+    if not _has_ltv_context(params, message=message):
+        return
 
     additional = params.get("additional_amounts")
     if not isinstance(additional, (list, tuple)) or not additional:
@@ -1026,6 +1037,56 @@ def _fill_collateral_and_loan_amounts(params: dict[str, Any]) -> None:
             params["loan_amount"] = int(round(loan_numeric))
         else:
             params["loan_amount"] = loan_value
+
+
+def _has_ltv_context(params: dict[str, Any], *, message: str | None) -> bool:
+    hints = {
+        str(params.get("calc_type")),
+        str(params.get("category")),
+    }
+    if any(
+        isinstance(token, str)
+        and token.strip().lower() in {"ltv", "loan_to_value"}
+        for token in hints
+    ):
+        return True
+
+    text = (message or "").lower()
+    if not text:
+        return False
+
+    disallow_keywords = (
+        "연소득",
+        "소득",
+        "연봉",
+        "부채",
+        "월 상환",
+        "월상환",
+        "dsr",
+        "dti",
+        "한도",
+        "중도상환",
+        "수수료",
+    )
+    if any(keyword in text for keyword in disallow_keywords):
+        return False
+
+    keywords = (
+        "ltv",
+        "담보",
+        "담보비율",
+        "담보 비율",
+        "담보인정",
+        "담보 인정",
+        "집값",
+        "주택가격",
+        "주택 가격",
+        "주택가액",
+        "매매가",
+        "시세",
+        "아파트값",
+    )
+    return any(keyword in text for keyword in keywords)
 
 
 def _summarize_compute_result(
@@ -1572,10 +1633,10 @@ def _infer_calc_category(
         _has_values(combined, "loan_amount") or _has_values(combined, "principal")
     ):
         return "ltv"
-    if _has_values(combined, "annual_income", "total_debt_payment"):
-        return "dti"
     if _has_values(combined, "annual_income", "annual_debt_service"):
         return "dsr"
+    if _has_values(combined, "annual_income", "total_debt_payment"):
+        return "dti"
     if _has_values(combined, "principal") and _has_non_empty_sequence(combined.get("interest_rates")):
         return "payment_sensitivity"
     if _has_values(combined, "loan_amount") and _has_non_empty_sequence(combined.get("interest_rates")):
@@ -1627,11 +1688,17 @@ def _has_non_empty_sequence(value: Any) -> bool:
 
 def _coerce_int(value: Any) -> Any:
     try:
+        if isinstance(value, bool):
+            return int(value)
         if isinstance(value, str):
             cleaned = value.replace(",", "").strip()
             if cleaned.endswith("개월"):
                 cleaned = cleaned[: -len("개월")].strip()
             return int(cleaned)
+        if isinstance(value, float):
+            if value.is_integer():
+                return int(value)
+            return value
         return int(value)
     except (TypeError, ValueError):
         return value
@@ -1650,12 +1717,12 @@ def _coerce_float(value: Any) -> Any:
 def _to_numeric(value: Any) -> float | None:
     """값을 float로 변환할 수 있으면 반환하고, 불가하면 None을 돌려준다."""
 
-    coerced_int = _coerce_int(value)
-    if isinstance(coerced_int, int):
-        return float(coerced_int)
     coerced_float = _coerce_float(value)
     if isinstance(coerced_float, float):
         return coerced_float
+    coerced_int = _coerce_int(value)
+    if isinstance(coerced_int, int):
+        return float(coerced_int)
     return None
 
 

--- a/src/services/chat_service.py
+++ b/src/services/chat_service.py
@@ -38,6 +38,8 @@ CALC_CATEGORY_MAP: dict[str, CalcType] = {
     "dsr": CalcType.DSR,
     "amortization": CalcType.AMORTIZATION,
     "payment_sensitivity": CalcType.PAYMENT_SENSITIVITY,
+    "prepayment_fee": CalcType.PREPAYMENT_FEE,
+    "prepayment": CalcType.PREPAYMENT_FEE,
 }
 
 CALCULATIONAL_CATEGORIES = set(CALC_CATEGORY_MAP.keys())
@@ -48,6 +50,7 @@ CALC_REQUIRED_PARAMS: dict[CalcType, list[str]] = {
     CalcType.DSR: ["annual_income", "annual_debt_service"],
     CalcType.AMORTIZATION: ["principal", "interest_rate", "months"],
     CalcType.PAYMENT_SENSITIVITY: ["principal", "interest_rates", "months"],
+    CalcType.PREPAYMENT_FEE: ["principal", "fee_rate"],
 }
 
 CALC_PARAM_LABELS: dict[str, str] = {
@@ -58,9 +61,12 @@ CALC_PARAM_LABELS: dict[str, str] = {
     "total_debt_payment": "총 부채 상환액",
     "annual_debt_service": "연간 부채 상환액",
     "principal": "대출 원금",
+    "principal_remaining": "대출 잔액",
+    "principal_outstanding": "대출 잔액",
     "interest_rate": "연 이자율(%)",
     "interest_rates": "이자율 목록",
     "months": "상환 개월 수",
+    "fee_rate": "중도상환 수수료율(%)",
 }
 
 CALC_CATEGORY_DISPLAY_LABELS: dict[str, str] = {
@@ -70,6 +76,7 @@ CALC_CATEGORY_DISPLAY_LABELS: dict[str, str] = {
     "amortization": "월 상환금액 (원리금 균등)",
     "monthly_payment": "월 상환금액 (원리금 균등)",
     "payment_sensitivity": "금리 민감도 분석",
+    "prepayment_fee": "중도상환 수수료",
 }
 
 RETRIEVAL_VALIDATION_FALLBACK_MESSAGE = (
@@ -251,6 +258,7 @@ class ChatService:
             calc_type: CalcType | None = None
             if normalized_category:
                 calc_type = CALC_CATEGORY_MAP.get(normalized_category)
+                params.setdefault("category", normalized_category)
             response_category = normalized_category or request.category
 
             missing: list[str] = []
@@ -275,6 +283,7 @@ class ChatService:
                     "missing_params": missing,
                     "calc_type": calc_type.value if calc_type else None,
                     "params": params,
+                    "category": calc_type.value if calc_type else normalized_category,
                 }
                 if needs_calc_type:
                     compute_payload["needs_calc_type"] = True
@@ -396,6 +405,7 @@ def _get_compute() -> ComputeRunner:
                     "missing_params": missing,
                     "calc_type": calc_type.value,
                     "params": params,
+                    "category": calc_type.value,
                 }
             result = compute_service.calculate(calc_type=calc_type, params=params)
             return {
@@ -403,6 +413,7 @@ def _get_compute() -> ComputeRunner:
                 "result": result,
                 "calc_type": calc_type.value,
                 "params": params,
+                "category": calc_type.value,
             }
 
     return _ComputeAdapter()
@@ -914,6 +925,12 @@ def _build_compute_answer_message(
                     f"{high_rate}이면 약 {high_payment}입니다."
                 )
 
+    if calc_type is CalcType.PREPAYMENT_FEE:
+        fee_amount = _to_numeric(result.get("fee_amount"))
+        if fee_amount is None:
+            return "계산 결과를 생성했습니다."
+        return f"예상 중도상환수수료는 약 {_format_currency(fee_amount)}입니다."
+
     return "계산 결과를 생성했습니다."
 
 
@@ -940,6 +957,9 @@ def _normalize_calc_params(params: dict[str, Any], *, message: str | None = None
 
         _copy_if_missing("loan_amount", "principal")
         _copy_if_missing("principal", "loan_amount")
+        _copy_if_missing("remaining_principal", "principal")
+        _copy_if_missing("outstanding_principal", "principal")
+        _copy_if_missing("principal", "remaining_principal")
         _copy_if_missing("term_months", "months")
         _copy_if_missing("months", "term_months")
         _copy_if_missing("rate", "interest_rate")
@@ -957,6 +977,9 @@ def _normalize_calc_params(params: dict[str, Any], *, message: str | None = None
         if key in normalized:
             normalized[key] = _coerce_int(normalized[key])
     for key in ("interest_rate", "rate"):
+        if key in normalized:
+            normalized[key] = _coerce_float(normalized[key])
+    for key in ("fee_rate",):
         if key in normalized:
             normalized[key] = _coerce_float(normalized[key])
 
@@ -1311,6 +1334,25 @@ def _summarize_compute_result(
             "highlights": highlights or None,
         }
 
+    if calc_type is CalcType.PREPAYMENT_FEE:
+        fee_amount = _to_numeric(result.get("fee_amount"))
+        if fee_amount is None:
+            return None
+        principal = _to_numeric(result.get("principal"))
+        fee_rate = _to_numeric(result.get("fee_rate"))
+        text = f"예상 중도상환수수료는 약 {_format_currency(fee_amount)}입니다."
+        highlights = []
+        if principal is not None:
+            highlights.append({"label": "대출 잔액", "value": _format_currency(principal)})
+        if fee_rate is not None:
+            highlights.append({"label": "수수료율", "value": _format_rate(fee_rate)})
+        return {
+            "text": text,
+            "value": int(round(fee_amount)),
+            "unit": "krw",
+            "highlights": highlights or None,
+        }
+
     return None
 
 
@@ -1633,6 +1675,8 @@ def _infer_calc_category(
         _has_values(combined, "loan_amount") or _has_values(combined, "principal")
     ):
         return "ltv"
+    if _has_values(combined, "principal") and _has_values(combined, "fee_rate"):
+        return "prepayment_fee"
     if _has_values(combined, "annual_income", "annual_debt_service"):
         return "dsr"
     if _has_values(combined, "annual_income", "total_debt_payment"):
@@ -1664,15 +1708,24 @@ def _infer_calc_category(
         "대출 한도",
         "한도 계산",
         "상환 계산",
+        "원리금균등",
     )
     sensitivity_keywords = ("민감도", "금리 변화", "payment sensitivity", "금리 민감도")
+    dsr_triggers = ("한도", "얼마까지 빌리", "얼마까지 빌릴", "얼마까지 빌려")
 
+    if any(keyword in message for keyword in ("중도상환", "수수료")):
+        return "prepayment_fee"
+    if (
+        (any(keyword in message for keyword in ("집값", "시세", "담보")) and any(keyword in message for keyword in ("대출", "융자")))
+        or "ltv" in message
+    ):
+        return "ltv"
+    if any(keyword in message for keyword in dsr_triggers) or any(keyword in message for keyword in dsr_keywords):
+        return "dsr"
     if any(keyword in message for keyword in ltv_keywords):
         return "ltv"
     if any(keyword in message for keyword in dti_keywords):
         return "dti"
-    if any(keyword in message for keyword in dsr_keywords):
-        return "dsr"
     if any(keyword in message for keyword in sensitivity_keywords):
         return "payment_sensitivity"
     if any(keyword in message for keyword in monthly_keywords):

--- a/src/services/compute_service.py
+++ b/src/services/compute_service.py
@@ -29,6 +29,7 @@ class ComputeService:
             CalcType.DSR: self._handle_dsr,
             CalcType.AMORTIZATION: self._handle_amortization,
             CalcType.PAYMENT_SENSITIVITY: self._handle_payment_sensitivity,
+            CalcType.PREPAYMENT_FEE: self._handle_prepayment_fee,
         }
 
     def calculate(self, *, calc_type: CalcType, params: dict[str, Any]) -> dict[str, Any]:
@@ -152,6 +153,18 @@ class ComputeService:
             "interest_rate_unit": rate_unit,
             "months": months,
             "sensitivity": sensitivity,
+        }
+
+    def _handle_prepayment_fee(self, params: dict[str, Any]) -> dict[str, Any]:
+        principal_key = "principal" if "principal" in params else "loan_amount"
+        principal = self._require_decimal(params, principal_key)
+        fee_rate = self._require_decimal(params, "fee_rate", allow_zero=False)
+        fee_amount = (principal * fee_rate / Decimal("100")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        return {
+            "principal": float(principal),
+            "fee_rate": float(fee_rate),
+            "fee_rate_unit": "percent",
+            "fee_amount": float(fee_amount),
         }
 
     # Helpers ------------------------------------------------------------------

--- a/src/services/compute_service.py
+++ b/src/services/compute_service.py
@@ -90,19 +90,42 @@ class ComputeService:
         }
 
     def _handle_amortization(self, params: dict[str, Any]) -> dict[str, Any]:
-        principal = self._require_decimal(params, "principal")
+        principal_key = "principal" if "principal" in params else "loan_amount"
+        principal = self._require_decimal(params, principal_key)
+
         interest_rate = self._require_decimal(params, "interest_rate", allow_zero=True)
-        months = self._require_int(params, "months", min_value=1)
+        annual_rate = float(interest_rate)
+        monthly_rate = (annual_rate / 100.0) / 12.0
+
+        months_value: Any = params.get("months")
+        if months_value is None:
+            if "term_months" in params:
+                months_value = params["term_months"]
+            elif "years" in params:
+                months_value = Decimal(str(params["years"])) * 12
+            elif "term_years" in params:
+                months_value = Decimal(str(params["term_years"])) * 12
+
+        if isinstance(months_value, Decimal):
+            months_value = int(months_value)
+
+        if months_value is None:
+            raise InvalidValueError("months 파라미터가 필요합니다.", field="months")
+
+        months = self._require_int({"months": months_value}, "months", min_value=1)
         schedule = calculate_amortization_schedule(
             principal=float(principal),
-            interest_rate=float(interest_rate),
+            interest_rate=monthly_rate * 12,
             months=months,
             as_dataframe=False,
         )
         monthly_payment = schedule[0]["payment"] if schedule else 0.0
         return {
             "principal": float(principal),
+            "loan_amount": float(principal),
             "interest_rate": float(interest_rate),
+            "interest_rate_unit": "annual_pct",
+            "interest_rate_display": f"{annual_rate:.2f}%",
             "months": months,
             "schedule": schedule,
             "monthly_payment": monthly_payment,
@@ -112,15 +135,21 @@ class ComputeService:
         principal = self._require_decimal(params, "principal")
         rates = self._require_rate_list(params, "interest_rates")
         months = self._require_int(params, "months", min_value=1)
+        rate_unit = _normalize_rate_unit(
+            params.get("interest_rates_unit")
+            or params.get("interest_rate_unit")
+            or params.get("rate_unit")
+        )
         sensitivity = calculate_payment_sensitivity(
             principal=float(principal),
-            interest_rates=[float(rate) for rate in rates],
+            interest_rates=[_convert_rate_to_decimal(float(rate), rate_unit) for rate in rates],
             months=months,
             as_dataframe=False,
         )
         return {
             "principal": float(principal),
             "interest_rates": [float(rate) for rate in rates],
+            "interest_rate_unit": rate_unit,
             "months": months,
             "sensitivity": sensitivity,
         }
@@ -184,6 +213,25 @@ class ComputeService:
 @lru_cache(maxsize=1)
 def get_compute_service() -> ComputeService:
     return ComputeService()
+
+
+def _normalize_rate_unit(value: Any) -> str:
+    if not isinstance(value, str):
+        return "percent"
+    normalized = value.strip().lower()
+    if not normalized:
+        return "percent"
+    if normalized in {"percent", "percentage", "%"}:
+        return "percent"
+    if normalized in {"decimal", "ratio"}:
+        return "decimal"
+    return "percent"
+
+
+def _convert_rate_to_decimal(value: float, unit: str) -> float:
+    if unit == "decimal":
+        return value
+    return value / 100.0
 
 
 

--- a/tests/unit/test_calc_param_normalization.py
+++ b/tests/unit/test_calc_param_normalization.py
@@ -35,6 +35,13 @@ def test_infers_ltv_when_message_mentions_ltv() -> None:
 
     assert normalized["collateral_value"] == 600_000_000
     assert normalized["loan_amount"] == 300_000_000
+    resolution = IntentResolution(intent=None, source="test", slots=params, confidence={})
+    category = _infer_calc_category(
+        ChatRequest(message="집값 6억, 대출 3억이면 LTV 얼마야?"),
+        resolution,
+        normalized,
+    )
+    assert category == "ltv"
 
 
 def test_monthly_debt_payment_converts_to_annual_and_prefers_dsr() -> None:
@@ -60,15 +67,14 @@ def test_monthly_debt_payment_converts_to_annual_and_prefers_dsr() -> None:
 def test_ltv_inference_not_triggered_for_prepayment_question() -> None:
     message = "중도상환수수료 1.2%가 남은 대출잔액 1억 5천만 원에 적용되면 수수료는 얼마야?"
     slots = {
-        "interest_rate": 1.2,
-        "interest_rate_unit": "percent",
-        "loan_amount": 100_000_000,
-        "additional_amounts": [5_000_000],
+        "fee_rate": 1.2,
+        "fee_rate_unit": "percent",
+        "loan_amount": 150_000_000,
     }
 
     normalized = _normalize_calc_params(dict(slots), message=message)
 
-    assert "collateral_value" not in normalized
+    assert normalized["principal"] == 150_000_000
     resolution = IntentResolution(intent=None, source="test", slots=slots, confidence={})
     category = _infer_calc_category(ChatRequest(message=message), resolution, normalized)
-    assert category != "ltv"
+    assert category == "prepayment_fee"

--- a/tests/unit/test_calc_param_normalization.py
+++ b/tests/unit/test_calc_param_normalization.py
@@ -1,0 +1,74 @@
+"""Tests for calculation parameter normalization heuristics."""
+
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+from src.api.schemas import ChatRequest
+from src.services.chat_service import IntentResolution, _infer_calc_category, _normalize_calc_params
+
+
+def test_does_not_infer_ltv_without_context() -> None:
+    params = {
+        "loan_amount": 60_000_000,
+        "additional_amounts": [800_000],
+    }
+
+    normalized = _normalize_calc_params(params, message="연소득 6000만원, 기존 부채 월 80만, DSR 40% 기준")
+
+    assert "collateral_value" not in normalized
+    assert normalized["loan_amount"] == 60_000_000
+
+
+def test_infers_ltv_when_message_mentions_ltv() -> None:
+    params = {
+        "loan_amount": 600_000_000,
+        "additional_amounts": [300_000_000],
+    }
+
+    normalized = _normalize_calc_params(params, message="집값 6억, 대출 3억이면 LTV 얼마야?")
+
+    assert normalized["collateral_value"] == 600_000_000
+    assert normalized["loan_amount"] == 300_000_000
+
+
+def test_monthly_debt_payment_converts_to_annual_and_prefers_dsr() -> None:
+    message = "연소득 6000만원, 기존 부채 월 80만, 금리 4.5%, 30년, DSR 40% 기준 대출 한도는?"
+    params = {
+        "annual_income": 60_000_000,
+        "monthly_debt_payment": 800_000,
+        "interest_rate": 4.5,
+        "interest_rate_unit": "percent",
+        "term_months": 360,
+        "target_dsr": 40.0,
+        "target_dsr_unit": "percent",
+    }
+
+    normalized = _normalize_calc_params(dict(params), message=message)
+
+    assert normalized["annual_debt_service"] == 9_600_000
+    resolution = IntentResolution(intent=None, source="test", slots=params, confidence={})
+    category = _infer_calc_category(ChatRequest(message=message), resolution, normalized)
+    assert category == "dsr"
+
+
+def test_ltv_inference_not_triggered_for_prepayment_question() -> None:
+    message = "중도상환수수료 1.2%가 남은 대출잔액 1억 5천만 원에 적용되면 수수료는 얼마야?"
+    slots = {
+        "interest_rate": 1.2,
+        "interest_rate_unit": "percent",
+        "loan_amount": 100_000_000,
+        "additional_amounts": [5_000_000],
+    }
+
+    normalized = _normalize_calc_params(dict(slots), message=message)
+
+    assert "collateral_value" not in normalized
+    resolution = IntentResolution(intent=None, source="test", slots=slots, confidence={})
+    category = _infer_calc_category(ChatRequest(message=message), resolution, normalized)
+    assert category != "ltv"

--- a/tests/unit/test_chat_service_calc.py
+++ b/tests/unit/test_chat_service_calc.py
@@ -87,6 +87,38 @@ def test_chat_service_normalizes_aliases_for_ltv(chat_service: ChatService) -> N
     assert data.get("primary_value") == pytest.approx(60.0, rel=1e-4)
 
 
+def test_chat_service_infers_ltv_category_from_message(chat_service: ChatService) -> None:
+    request = ChatRequest(message="집값 6억, 대출 3억이면 LTV 얼마야?")
+
+    response = chat_service.handle(request)
+
+    assert response.category == "ltv"
+    data = response.data
+    assert data["category"] == "ltv"
+    assert _as_int(data["params"]["collateral_value"]) == 600_000_000
+    assert _as_int(data["params"]["loan_amount"]) == 300_000_000
+    assert "summary" in data and "LTV" in data["summary"]
+
+
+def test_chat_service_handles_prepayment_fee(chat_service: ChatService) -> None:
+    request = ChatRequest(
+        message="중도상환수수료 1.2%가 남은 대출잔액 1억5천만 원에 적용되면 수수료는 얼마야?"
+    )
+
+    response = chat_service.handle(request)
+
+    assert response.category == "prepayment_fee"
+    data = response.data
+    assert data["category"] == "prepayment_fee"
+    assert data["calc_type"] == CalcType.PREPAYMENT_FEE.value
+    assert _as_int(data["params"]["principal"]) == 150_000_000
+    assert data["params"]["fee_rate"] == pytest.approx(1.2)
+    assert data["result"]["fee_amount"] == pytest.approx(1_800_000.0, rel=1e-9)
+    assert "summary" in data and "중도상환수수료" in data["summary"]
+    assert data.get("primary_value") == 1_800_000
+    assert data.get("primary_value_unit") == "krw"
+
+
 def test_chat_service_derives_collateral_from_additional(chat_service: ChatService) -> None:
     request = ChatRequest(
         message="담보가치 5억에 3억 대출이면 LTV 얼마야?",

--- a/tests/unit/test_compute_service_rates.py
+++ b/tests/unit/test_compute_service_rates.py
@@ -32,3 +32,19 @@ def test_amortization_uses_percentage_rate() -> None:
     assert result["interest_rate"] == 4.2
     assert result["interest_rate_unit"] == "annual_pct"
     assert result["interest_rate_display"] == "4.20%"
+
+
+def test_prepayment_fee_calculation() -> None:
+    service = ComputeService()
+
+    result = service.calculate(
+        calc_type=CalcType.PREPAYMENT_FEE,
+        params={
+            "principal": 150_000_000,
+            "fee_rate": 1.2,
+        },
+    )
+
+    assert math.isclose(result["fee_amount"], 1_800_000.0, rel_tol=1e-9)
+    assert result["principal"] == 150_000_000.0
+    assert result["fee_rate"] == 1.2

--- a/tests/unit/test_compute_service_rates.py
+++ b/tests/unit/test_compute_service_rates.py
@@ -1,0 +1,34 @@
+"""ComputeService interest rate normalisation tests."""
+
+from pathlib import Path
+import sys
+
+import math
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+from src.api.schemas import CalcType
+from src.services.compute_service import ComputeService
+
+
+def test_amortization_uses_percentage_rate() -> None:
+    service = ComputeService()
+
+    result = service.calculate(
+        calc_type=CalcType.AMORTIZATION,
+        params={
+            "principal": 400_000_000,
+            "interest_rate": 4.2,
+            "interest_rate_unit": "percent",
+            "months": 360,
+        },
+    )
+
+    assert math.isclose(result["monthly_payment"], 1_956_068.69, rel_tol=1e-6)
+    assert result["interest_rate"] == 4.2
+    assert result["interest_rate_unit"] == "annual_pct"
+    assert result["interest_rate_display"] == "4.20%"

--- a/tests/unit/test_slot_intent.py
+++ b/tests/unit/test_slot_intent.py
@@ -35,9 +35,10 @@ def test_prepayment_fee_percentage_not_treated_as_amount() -> None:
     message = "중도상환수수료 1.2%가 남은 대출잔액 1억 5천만 원에 적용되면 수수료는 얼마야?"
     slots = extract_intent_and_slots(message)["slots"]
 
-    assert slots["interest_rate"] == 1.2
-    assert slots["interest_rate_unit"] == "percent"
-    assert slots["loan_amount"] == 100_000_000
+    assert slots["fee_rate"] == 1.2
+    assert slots["fee_rate_unit"] == "percent"
+    assert slots["principal"] == 150_000_000
+    assert slots["loan_amount"] == 150_000_000
 
 
 def test_dsr_question_extracts_income_debt_and_target() -> None:
@@ -48,3 +49,10 @@ def test_dsr_question_extracts_income_debt_and_target() -> None:
     assert slots["monthly_debt_payment"] == 800_000
     assert slots["annual_debt_service"] == 9_600_000
     assert slots["target_dsr"] == 40.0
+
+
+def test_compound_korean_amount_parsed_correctly() -> None:
+    message = "집값 1억5천만 원"
+    slots = extract_intent_and_slots(message)["slots"]
+
+    assert slots["collateral_value"] == 150_000_000

--- a/tests/unit/test_slot_intent.py
+++ b/tests/unit/test_slot_intent.py
@@ -1,0 +1,50 @@
+"""Tests for mortgage slot extraction heuristics."""
+
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+from src.nlp.slot_intent import extract_intent_and_slots
+
+
+def test_interest_rates_not_misclassified_as_amounts() -> None:
+    message = "주택담보대출 금리 4.2%, 30년 원리금균등으로 4억 원 빌리면 월 납입액이 얼마일까?"
+    slots = extract_intent_and_slots(message)["slots"]
+
+    assert slots["interest_rate"] == 4.2
+    assert slots["interest_rate_unit"] == "percent"
+    assert slots["term_months"] == 360
+    assert slots["loan_amount"] == 400_000_000
+
+
+def test_rate_change_question_does_not_create_fake_principal() -> None:
+    message = "변동금리 3.5%에서 5%로 오르면 월 상환액이 얼마나 늘어나?"
+    slots = extract_intent_and_slots(message)["slots"]
+
+    assert slots["interest_rate"] == 3.5
+    assert slots["interest_rate_unit"] == "percent"
+    assert "loan_amount" not in slots
+
+
+def test_prepayment_fee_percentage_not_treated_as_amount() -> None:
+    message = "중도상환수수료 1.2%가 남은 대출잔액 1억 5천만 원에 적용되면 수수료는 얼마야?"
+    slots = extract_intent_and_slots(message)["slots"]
+
+    assert slots["interest_rate"] == 1.2
+    assert slots["interest_rate_unit"] == "percent"
+    assert slots["loan_amount"] == 100_000_000
+
+
+def test_dsr_question_extracts_income_debt_and_target() -> None:
+    message = "연소득 6000만원, 기존 부채 월 80만, 금리 4.5%, 30년, DSR 40% 기준 대출 한도는?"
+    slots = extract_intent_and_slots(message)["slots"]
+
+    assert slots["annual_income"] == 60_000_000
+    assert slots["monthly_debt_payment"] == 800_000
+    assert slots["annual_debt_service"] == 9_600_000
+    assert slots["target_dsr"] == 40.0


### PR DESCRIPTION
## ⭐Key Changes
- 금리/기간 단위 정규화 누락으로 월 상환액이 비정상(연 4.2% → 4.2로 처리)되던 문제 수정
- LTV 강제 보정 로직 개선: DSR/DTI/한도/중도상환 질문이 LTV로 잘못 분류되는 문제 해결
- 중도상환수수료 계산 로직 추가 (prepayment_fee category 신설)
- 필요 파라미터 안내(need_inputs, followups) 로직 안정화 — 부족한 슬롯 자동 요청
- interest_rate_display 포맷 개선 (4.2% → 4.20%)

- 주택담보대출 금리 4.2%, 30년 원리금균등으로 4억 원 빌리면 월 납입액이 얼마일까?
→ 월 예상 상환액은 약 1,956,069원입니다. (원금 400,000,000원, 기간 360개월, 금리 4.20%)
- 집값 6억, 대출 3억이면 LTV 얼마야?
→ LTV는 약 50.00%입니다. (담보 600,000,000원, 대출 300,000,000원)
- 중도상환수수료 1.2%가 남은 대출잔액 1억5천만 원에 적용되면 수수료는 얼마야?
→ 예상 중도상환수수료는 약 1,800,000원입니다.
- 연소득 6000만원, 기존 부채 월 80만, DSR 40% 기준 대출 한도는?
→ DSR 계산 정상 작동 (약 16.00%, 연소득 60,000,000원, 원리금 상환 9,600,000원)
- LTV 계산이 필요해. 담보가치 8억이고 대출은 4억5천
→ 계산은 정상 작동하나 “4억5천”이 400,005,000으로 인식되는 파싱 보정 필요